### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm run build
 
       - name: Publish Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@2.22
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ardean/video-chat/video-chat
           username: $GITHUB_ACTOR


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore